### PR TITLE
ci: avoid duplicate runs; package on main/tags

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,9 +1,9 @@
 name: Build Package
 
 on:
-  # Build on PRs (to validate packaging) and on version tags for releases.
-  pull_request:
+  # Build package on main and on version tags for releases.
   push:
+    branches: [ 'main' ]
     tags: [ 'v*' ]
   workflow_dispatch:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,10 +1,17 @@
 name: Lint and Test
 
 on:
-  push:
-    branches: ["**"]
   pull_request:
     branches: ["**"]
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: ["main"]
+    tags: ["v*"]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary
Avoid duplicate CI runs on PRs by refining workflow triggers and adding concurrency.

## Changes
- `tests.yml`
  - Trigger CI on `pull_request` for all commits in PR (opened, synchronize, reopened, ready_for_review)
  - Limit `push` triggers to `main` and tags `v*`
  - Add `workflow_dispatch` for manual runs
  - Add `concurrency` to cancel in-progress runs on newer commits
- `package.yml`
  - Build package on `push` to `main` and tags `v*`
  - Removed `pull_request` trigger to avoid duplicate builds

## Rationale
- PR commits now run CI exactly once (via `pull_request`)
- `main` still runs CI on push; releases build on tags
- Concurrency keeps CI responsive on rapid pushes

_No functional code changes._
