### PR TITLE
ci: fix GH Actions secrets usage in package.yml

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -35,6 +35,8 @@ jobs:
     needs: build
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    env:
+      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
     steps:
       - name: Download built artifacts
         uses: actions/download-artifact@v4
@@ -50,8 +52,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to PyPI (optional)
-        if: ${{ secrets.PYPI_API_TOKEN != '' }}
+        if: ${{ env.PYPI_API_TOKEN != '' }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          password: ${{ env.PYPI_API_TOKEN }}


### PR DESCRIPTION
Fixes workflow error: `Unrecognized named-value: 'secrets'` by mapping the secret to a job env var and referencing `env.PYPI_API_TOKEN` in the step `if:` and inputs.

- Add `env: PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}` at job level
- Use `if: ${{ env.PYPI_API_TOKEN != '' }}` and `password: ${{ env.PYPI_API_TOKEN }}`

This unblocks tag builds from publishing to PyPI.