### PR TITLE
ci: grant contents: write for release job

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -35,6 +35,8 @@ jobs:
     needs: build
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
     steps:


### PR DESCRIPTION
Grant `contents: write` permission to the `release` job so `softprops/action-gh-release` can create a GitHub Release.

- Add `permissions: contents: write` at job level
- Keeps PyPI secret fix from earlier PR

This should resolve the 403 “Resource not accessible by integration” error when creating releases from tags.